### PR TITLE
Remove final keyword from client

### DIFF
--- a/Service/Client.php
+++ b/Service/Client.php
@@ -2,7 +2,7 @@
 
 namespace Domnikl\StatsdBundle\Service;
 
-final class Client
+class Client
 {
     /**
      * @var \Domnikl\Statsd\Client


### PR DESCRIPTION
Having the client be `final` makes it hard to mock when doing unit testing.